### PR TITLE
Add state to simulate re-renders

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,10 @@ function getHotkeys(ref = window.document) {
 
 function App() {
   const rootRef = React.createRef;
+  const [inputValue, setInputValue] = useState("");
+  console.log(inputValue);
   useEffect(() => {
+    console.log("install hotkeys");
     const hotKeys = getHotkeys(rootRef.current);
     for (const el of hotKeys) {
       install(el);
@@ -25,6 +28,13 @@ function App() {
     <div ref={rootRef} id="app-root">
       <h1>Hello CodeSandbox</h1>
       <h2>Start editing to see some magic happen!</h2>
+      <input
+        type="text"
+        initialvalue={inputValue}
+        onInput={e => {
+          setInputValue(e.target.value);
+        }}
+      />
       <button
         data-hotkey="a y"
         onClick={e => {


### PR DESCRIPTION
Add an input and `useState` call to force React to re-render the application, exemplifying `useEffect`'s cacheing.